### PR TITLE
Fixed typo and add-user on click form bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Today we're going to talk about Ajax, and how we can use jQuery to make Ajax req
 
 Ajax allows us to retreive data from a server or API without refreshing the entire page. Before Ajax, the entire page would need to refresh in order to retreive new data.
 
-Ajax has the helped web to become what it is today. Can you imagine making a facebook post and having it refresh the entire website?
+Ajax has helped the web to become what it is today. Can you imagine making a facebook post and having it refresh the entire website?
 
 If you look at the index.html of this app, we have three things. We have a form that takes in data, a 'get current users' section, and a 'recently added user' section.
 
@@ -175,7 +175,7 @@ Our data is currently the values from our input fields.
 - Inside our error function, we'll alert the user that something went wrong.
 
 ``` javascript
-  $('body').on('click', '.js-add-user', function (e) {
+  $('.js-add-user').on('click', 'button:first', function (e) {
     e.preventDefault();
     var userName = $('.js-name').val();
     var userJob = $('.js-job').val();


### PR DESCRIPTION
Two words placement was inverted in one of the sentences in the description.

When you clicked on the .js-add-user form it submitted the form, which included clicking on input boxes or even clicking on the cancel button.
